### PR TITLE
feat(twilio_sms): re-add sms-log that was originally present in 12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/twilio_sms/__manifest__.py
+++ b/twilio_sms/__manifest__.py
@@ -8,6 +8,7 @@
     "depends": ["sms"],
     "external_dependencies": {"python": ["twilio", "phonenumbers"]},
     "data": [
+        "security/ir.model.access.csv",
         "views/res_config_settings.xml",
         "views/sms_log.xml",
     ],

--- a/twilio_sms/__manifest__.py
+++ b/twilio_sms/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.1.0",
     "name": "twilio_sms",
     "summary": "Twilio SMS Gateway",
     "author": "Glo Networks",
@@ -7,5 +7,8 @@
     "license": "Other proprietary",
     "depends": ["sms"],
     "external_dependencies": {"python": ["twilio", "phonenumbers"]},
-    "data": ["views/res_config_settings.xml"],
+    "data": [
+        "views/res_config_settings.xml",
+        "views/sms_log.xml",
+    ],
 }

--- a/twilio_sms/models/__init__.py
+++ b/twilio_sms/models/__init__.py
@@ -1,2 +1,3 @@
 from . import sms_api
+from . import sms_log
 from . import res_config_settings

--- a/twilio_sms/models/res_config_settings.py
+++ b/twilio_sms/models/res_config_settings.py
@@ -19,3 +19,4 @@ class ResConfigSettings(models.TransientModel):
     twilio_country_code = fields.Char(
         config_parameter="twilio_sms.default_country_code",
     )
+    twilio_log = fields.Boolean(config_parameter="twilio_sms.log")

--- a/twilio_sms/models/sms_api.py
+++ b/twilio_sms/models/sms_api.py
@@ -32,11 +32,10 @@ class SmsApi(models.AbstractModel):
                     phonenumbers.PhoneNumberType.MOBILE,
                     phonenumbers.PhoneNumberType.UNKNOWN,
                 ):
-                    err = _("Does not appear to be a mobile number")
                     res.append(
                         {
                             "error_code": "Invalid Number",
-                            "error_message": err,
+                            "error_message": _("Does not appear to be a mobile number"),
                         }
                     )
                     continue

--- a/twilio_sms/models/sms_api.py
+++ b/twilio_sms/models/sms_api.py
@@ -19,7 +19,7 @@ class SmsApi(models.AbstractModel):
         country_code = icp.get_param("twilio_sms.default_country_code", default="GB")
         send_as = icp.get_param("twilio_sms.from", default="")
         create_log = icp.get_param("twilio_sms.log", default=False)
-        model_log = self.env["twilio.sms.log"].sudo()
+        model_log = self.env["twilio_sms.log"].sudo()
 
         client = Client(account_sid, auth_token)
         res = []

--- a/twilio_sms/models/sms_log.py
+++ b/twilio_sms/models/sms_log.py
@@ -24,7 +24,7 @@ class TwilioSmsLog(models.Model):
         required=True,
     )
 
-    @api.autovacuum()
+    @api.autovacuum
     def _gc_log(self):
         self._cr.execute(
             """

--- a/twilio_sms/models/sms_log.py
+++ b/twilio_sms/models/sms_log.py
@@ -1,0 +1,36 @@
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+MAX_AGE = 90 * 86400
+
+
+class TwilioSmsLog(models.Model):
+    _name = "twilio_sms.log"
+    _description = "Twilio SMS Log"
+    _order = "create_date desc"
+
+    to = fields.Char()
+    body = fields.Text()
+    account_sid = fields.Char()
+    api_response = fields.Text()
+    state = fields.Selection(
+        [
+            ("done", "Done"),
+            ("error", "Error"),
+        ],
+        default="done",
+        required=True,
+    )
+
+    @api.autovacuum()
+    def _gc_log(self):
+        self._cr.execute(
+            """
+            DELETE FROM twilio_sms_log
+            WHERE create_date < (NOW() AT TIME ZONE 'UTC' - INTERVAL '%s SECONDS')
+            """,
+            [MAX_AGE],
+        )
+        _logger.info("GC'd %d twilio_sms_log entries", self._cr.rowcount)

--- a/twilio_sms/security/ir.model.access.csv
+++ b/twilio_sms/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_twilio_sms_log,access_twilio_sms_log,model_twilio_sms_log,base.group_user,1,1,1,1

--- a/twilio_sms/views/res_config_settings.xml
+++ b/twilio_sms/views/res_config_settings.xml
@@ -23,6 +23,14 @@
                         </div>
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="twilio_log" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="twilio_log" class="o_form_label" />
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
                         <div class="o_setting_right_pane">
                             <div class="m16">
                                 <label for="twilio_sid" class="o_form_label" />

--- a/twilio_sms/views/sms_log.xml
+++ b/twilio_sms/views/sms_log.xml
@@ -3,7 +3,6 @@
         <field name="name">Twilio SMS Logs</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">twilio_sms.log</field>
-        <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
     </record>
 

--- a/twilio_sms/views/sms_log.xml
+++ b/twilio_sms/views/sms_log.xml
@@ -1,0 +1,53 @@
+<odoo>
+    <record id="action_window_twilio_sms_log" model="ir.actions.act_window">
+        <field name="name">Twilio SMS Logs</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">twilio_sms.log</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="view_twilio_sms_log_tree" model="ir.ui.view">
+        <field name="name">view_twilio_sms_log_tree</field>
+        <field name="model">twilio_sms.log</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="to" />
+                <field name="create_date" />
+                <field name="state" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_twilio_sms_log_form" model="ir.ui.view">
+        <field name="name">view_twilio_sms_log_form</field>
+        <field name="model">twilio_sms.log</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <field name="state" widget="statusbar" />
+                </header>
+                <sheet>
+                    <group>
+                        <field name="to" />
+                        <field name="account_sid" />
+                        <field name="body" />
+                        <field name="api_response" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <menuitem
+        id="menu_custom_twilio_sms_root"
+        parent="base.menu_custom"
+        name="Twilio SMS"
+    />
+    <menuitem
+        id="menu_custom_twilio_sms_log"
+        parent="menu_custom_twilio_sms_root"
+        name="Logs"
+        action="action_window_twilio_sms_log"
+    />
+</odoo>


### PR DESCRIPTION
## Description

Re-adds optional logging support against `twilio_sms` as per the original 12.0 implementation. 
Optionally enable/disable it, and also setup an autovacuum to keep the table under control.

Fixes GH108567

Associated risk level low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

